### PR TITLE
Fix Vercel deploy: pin Node 24.x (project was on discontinued 18.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "email": "alexppavlov93@gmail.com",
     "url": "https://alexpavlov.dev"
   },
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Problem

After merging #13, the Vercel deploy **errored in ~2s** before building:

> Found invalid or discontinued Node.js Version: "18.x". Please set Node.js Version to 24.x in your Project Settings.

The Vercel project (last deployed 877 days ago) is pinned to **Node 18.x**, which Vercel now rejects outright. Next.js 16 / React 19 require Node ≥ 20.9 anyway.

## Fix

Add `engines.node: "24.x"` to `package.json`. Per [Vercel docs](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions), `engines.node` **takes precedence over the Project Settings** Node version, so this unblocks the build without touching the dashboard. 24.x matches the local dev Node and Vercel's current default.

The preview deployment on this PR should build green (using Node 24.x), confirming the fix before merge.

> Optional cleanup: in Vercel → Project → Settings → Build & Deployment → Node.js Version, set it to 24.x to remove the stale 18.x value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)