### PR TITLE
Frontmatter cleanup + SEO/rendering fixes

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -23,26 +23,15 @@ content:
         default: draft
         options:
           values: [published, draft]
-      - name: author
-        label: Author
-        type: object
-        fields:
-          - { name: name, label: Name, type: string }
-          - { name: picture, label: Picture URL, type: string }
       - name: slug
         label: Slug
         type: string
         required: true
         pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
       - { name: description, label: Description, type: text }
-      - { name: tags, label: 'Tags (comma-separated)', type: string }
+      - { name: tags, label: Tags, type: string, list: true }
       - { name: coverImage, label: Cover image, type: image }
-      - name: featured
-        label: Featured
-        type: select
-        default: 'no'
-        options:
-          values: ['yes', 'no']
+      - { name: featured, label: Featured, type: boolean, default: false }
       - { name: publishedAt, label: Published at, type: datetime, required: true }
       - { name: body, label: Body, type: rich-text }
 
@@ -66,16 +55,10 @@ content:
         default: published
         options:
           values: [published, draft]
-      - name: author
-        label: Author
-        type: object
-        fields:
-          - { name: name, label: Name, type: string }
-          - { name: picture, label: Picture URL, type: string }
       - { name: slug, label: Slug, type: string, required: true }
       - { name: description, label: Description, type: text }
       - { name: coverImage, label: Cover image, type: image }
-      - { name: technologies, label: 'Technologies (comma-separated)', type: string }
+      - { name: technologies, label: Technologies, type: string, list: true }
       - { name: github, label: GitHub URL, type: string }
       - { name: link, label: Live link, type: string }
       - { name: publishedAt, label: Published at, type: datetime, required: true }
@@ -98,12 +81,6 @@ content:
         default: published
         options:
           values: [published, draft]
-      - name: author
-        label: Author
-        type: object
-        fields:
-          - { name: name, label: Name, type: string }
-          - { name: picture, label: Picture URL, type: string }
       - { name: slug, label: Slug, type: string, required: true }
       - { name: description, label: Description, type: text }
       - { name: coverImage, label: Cover image, type: image }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -20,11 +20,11 @@ export const metadata = {
 export default function Home() {
 
   const featuredPosts = allPosts
-    .filter(p => p.status == 'published' && p?.featured == 'yes')
+    .filter(p => p.status == 'published' && p.featured)
     .sort((a, b) => compareDesc(new Date(a.publishedAt), new Date(b.publishedAt)));
 
   const posts = allPosts
-    .filter(p => p.status == 'published' && (p?.featured == 'no' || !p?.featured))
+    .filter(p => p.status == 'published' && !p.featured)
     .sort((a, b) => compareDesc(new Date(a.publishedAt), new Date(b.publishedAt)));
 
   return (

--- a/app/blog/posts/[slug]/page.tsx
+++ b/app/blog/posts/[slug]/page.tsx
@@ -51,7 +51,7 @@ const PostPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
 
       
 
-      <div dangerouslySetInnerHTML={{ __html: post.html }} className='max-w-max prose prose-dark prose-invert prose-lg mb-5 mt-5'>
+      <div dangerouslySetInnerHTML={{ __html: post.html }} className='max-w-max prose prose-invert prose-lg mb-5 mt-5'>
       </div>
       <Giscus />
     </article>

--- a/app/blog/projects/page.tsx
+++ b/app/blog/projects/page.tsx
@@ -34,7 +34,7 @@ export default function Projects() {
                                 imgSrc={d.coverImage}
                                 href={d.link}
                                 github={d.github}
-                                tech={d.technologies?.split(',')}
+                                tech={d.technologies}
                             />
                         ))}
                     </div>

--- a/app/blog/tags/[slug]/page.tsx
+++ b/app/blog/tags/[slug]/page.tsx
@@ -3,6 +3,9 @@ import { allPosts } from 'content-collections'
 import { PostCard } from 'app/components/post-card';
 import { notFound } from 'next/navigation';
 
+export const generateStaticParams = async () =>
+  [...new Set(allPosts.flatMap(post => post.tags))].map((slug) => ({ slug }))
+
 const TagPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
 
     const { slug: tag } = await params;

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -3,9 +3,7 @@ import Tag from "app/components/tag";
 import { allPosts } from "content-collections";
 
 export default function TagsPage() {
-  const allTags = allPosts
-    .map(post => post.tags?.split(",").map(p => p.trim()))
-    .flat();
+  const allTags = allPosts.flatMap(post => post.tags);
 
   const tags = [...new Set(allTags)];
 

--- a/app/components/about-me.tsx
+++ b/app/components/about-me.tsx
@@ -6,7 +6,7 @@ export function AboutMe() {
     "use client";
 
     const aboutMe = allPages
-      .find(p => p.slug == 'about-me')?.content;
+      .find(p => p.slug == 'about-me')?.html;
 
     return (
       <div className="pt-6">
@@ -14,9 +14,10 @@ export function AboutMe() {
           Hi, I am{' '}
           <span className="text-primary-color-500 dark:text-primary-color-dark-500">Alex</span>
         </h1>
-        <p className="pt-5 text-lg text-gray-600 dark:text-gray-300">
-          {aboutMe}
-        </p>
+        <div
+          className="pt-5 text-lg text-gray-600 dark:text-gray-300"
+          dangerouslySetInnerHTML={{ __html: aboutMe ?? '' }}
+        />
         <p className="pt-10 text-lg leading-7 text-slate-600 dark:text-slate-300">
           This is my place for{' '}
           <RoughNotation

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -11,8 +11,7 @@ export function Header({navLinks} : {navLinks: {href: string, title: string}[]})
     <header className="md:flex items-center justify-between py-10">
       <div>
         <div className="text-primary-color dark:text-primary-color-dark flex items-center justify-between text-xl font-semibold">
-          <Link href='/'  passHref legacyBehavior>
-            <a>
+          <Link href='/'>
             <Typewriter
               options={{
                 strings: [`~${pathname} `],
@@ -22,7 +21,6 @@ export function Header({navLinks} : {navLinks: {href: string, title: string}[]})
                 delay: 0
               }}
             />
-            </a>
           </Link>
         </div>
       </div>

--- a/app/components/post-card.tsx
+++ b/app/components/post-card.tsx
@@ -15,13 +15,11 @@ export function PostCard(post: Post) {
               <h2 className="text-2xl font-bold leading-8 tracking-tight">
                 <Link
                   href={`/${post.url}`}
-                  legacyBehavior>
-                  <a className="text-gray-900 transition duration-500 ease-in-out hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-500">{post.title}</a>
-                </Link>
+                  className="text-gray-900 transition duration-500 ease-in-out hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-500">{post.title}</Link>
               </h2>
             </div>
             <div className="flex flex-wrap">
-              {post.tags!.split(",").map((tag) => (
+              {post.tags.map((tag) => (
                 <Tag key={tag} text={tag} />
               ))}
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,10 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 
 const inter = Inter({ subsets: ['latin'] })
 
+export const metadata = {
+  metadataBase: new URL('https://alexpavlov.dev'),
+}
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className='dark scroll-smooth'>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next'
-import { allPosts, allPages } from "content-collections";
+import { allPosts } from "content-collections";
 
 export default function sitemap(): MetadataRoute.Sitemap {
 
@@ -11,15 +11,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
             priority: 1,
         } as any
     }).concat(
-        allPages.map(p => {
-            return {
-                url: `https://alexpavlov.dev/${p.flattenedPath}`,
-                lastModified: new Date(),
-                changeFrequency: 'monthly',
-                priority: 1,
-            } as any
-        }
-    )).concat(
         [
             {
                 url: `https://alexpavlov.dev/blog`,

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -34,7 +34,11 @@ async function toHtml(markdown: string): Promise<string> {
   return String(file)
 }
 
-const author = z.object({ name: z.string(), picture: z.string() })
+// Single-author blog: one source of truth instead of repeating author in every file.
+const AUTHOR = {
+  name: 'Alex Pavlov',
+  picture: 'https://avatars.githubusercontent.com/u/6662454?v=4',
+}
 
 const posts = defineCollection({
   name: 'posts',
@@ -44,12 +48,11 @@ const posts = defineCollection({
   schema: z.object({
     title: z.string(),
     status: z.enum(['published', 'draft']).default('draft'),
-    author: author.optional(),
     slug: z.string(),
     description: z.string().optional().default(''),
-    tags: z.string().optional().default(''),
+    tags: z.array(z.string()).optional().default([]),
     coverImage: z.string().optional().default(''),
-    featured: z.string().optional().default(''),
+    featured: z.boolean().optional().default(false),
     publishedAt: z.string(),
     content: z.string(),
   }),
@@ -57,6 +60,7 @@ const posts = defineCollection({
     const flattenedPath = `posts/${doc.slug}`
     return {
       ...doc,
+      author: AUTHOR,
       html: await toHtml(doc.content),
       url: `blog/${flattenedPath}`,
       flattenedPath,
@@ -72,11 +76,10 @@ const projects = defineCollection({
   schema: z.object({
     title: z.string(),
     status: z.string(),
-    author: author.optional(),
     slug: z.string(),
     description: z.string().optional().default(''),
     coverImage: z.string().optional().default(''),
-    technologies: z.string().optional().default(''),
+    technologies: z.array(z.string()).optional().default([]),
     github: z.string().optional().default(''),
     link: z.string().optional().default(''),
     publishedAt: z.string(),
@@ -86,6 +89,7 @@ const projects = defineCollection({
     const flattenedPath = `projects/${doc.slug}`
     return {
       ...doc,
+      author: AUTHOR,
       html: await toHtml(doc.content),
       url: `blog/${flattenedPath}`,
       flattenedPath,
@@ -101,7 +105,6 @@ const pages = defineCollection({
   schema: z.object({
     title: z.string(),
     status: z.string(),
-    author: author.optional(),
     slug: z.string(),
     description: z.string().optional().default(''),
     coverImage: z.string().optional().default(''),
@@ -112,6 +115,8 @@ const pages = defineCollection({
     const flattenedPath = `pages/${doc.slug}`
     return {
       ...doc,
+      author: AUTHOR,
+      html: await toHtml(doc.content),
       url: `blog/${flattenedPath}`,
       flattenedPath,
     }

--- a/content/pages/about-me.md
+++ b/content/pages/about-me.md
@@ -1,9 +1,6 @@
 ---
 title: 'About Me'
 status: 'published'
-author:
-  name: 'Alex Pavlov '
-  picture: 'https://avatars.githubusercontent.com/u/6662454?v=4'
 slug: 'about-me'
 description: ''
 coverImage: ''

--- a/content/posts/anki-and-zettelkasten.md
+++ b/content/posts/anki-and-zettelkasten.md
@@ -1,16 +1,13 @@
 ---
 title: How to Integrate Anki With Zettelkasten?
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: anki-and-zettelkasten
 description: Why bother to use Anki in the first place if you can quickly access
   the information in your Zettelkasten? Because quick access to memory is at the
   foundation of creative thought and problem-solving.
-tags: anki, zettelkasten
+tags: [anki, zettelkasten]
 coverImage: /images/pavlovtech_german_scientist_memorising_flash_cards_e6bd9f50-fe19-4316-b325-d1fdc2f2ba5d-Y4Nz.png
-featured: no
+featured: false
 publishedAt: 2023-01-23T15:42:12.174Z
 ---
 Why bother to use Anki in the first place if you can quickly access the information in your Zettelkasten? Because quick access to memory is at the foundation of creative thought and problem-solving. It enables speed in associative thinking to see patterns, in ways not possible if you need to keep routinely looking up information.

--- a/content/posts/append-and-prepend-methods-in-dotnet.md
+++ b/content/posts/append-and-prepend-methods-in-dotnet.md
@@ -1,13 +1,10 @@
 ---
 title: Two Useful Methods of IEnumerable
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: append-and-prepend-methods-in-dotnet
 description: A nice and functional way to add a single element to the IEnumerable collection
-tags: csharp, dotnet
-featured: no
+tags: [csharp, dotnet]
+featured: false
 publishedAt: 2023-09-06T16:42:28.000Z
 ---
 I found myself writing this piece of code:

--- a/content/posts/asnync-obj-conscruction-in-scharp.md
+++ b/content/posts/asnync-obj-conscruction-in-scharp.md
@@ -1,14 +1,11 @@
 ---
 title: Asynchronous Initialization In C#
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: asnync-obj-conscruction-in-scharp
 description: You can’t have an async constructor in C#, but sometimes you need
   to have async initialization logic.
-tags: csharp, dotnet
-featured: no
+tags: [csharp, dotnet]
+featured: false
 publishedAt: 2023-09-06T15:42:12.174Z
 ---
 You can’t have an async constructor in C#, but sometimes you need to have async initialization logic.

--- a/content/posts/badass-dotnet-dev.md
+++ b/content/posts/badass-dotnet-dev.md
@@ -1,12 +1,9 @@
 ---
 title: 'How to Become a Badass .NET Developer'
 status: 'published'
-author:
-  name: 'Alex Pavlov '
-  picture: 'https://avatars.githubusercontent.com/u/6662454?v=4'
 slug: 'badass-dotnet-dev'
-featured: 'yes'
-tags: 'csharp, career'
+featured: true
+tags: [csharp, career]
 description: 'This article will describe a roadmap to becoming a badass .NET Software Engineer. I will start with the C# language itself and walk you through the frameworks and technologies you need to master on your journey.'
 coverImage: '/assets/badass-dev-logo.webp'
 publishedAt: '2023-03-20T15:42:12.174Z'

--- a/content/posts/cqrs-mediatr-common-mistake.md
+++ b/content/posts/cqrs-mediatr-common-mistake.md
@@ -1,13 +1,10 @@
 ---
 title: The wrong way to use CQRS and MediatR
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: cqrs-mediatr-common-mistake
 description: This post will explore a common mistake in projects MetiatR and CQRS.
-tags: cqrs, dotnet
-featured: yes
+tags: [cqrs, dotnet]
+featured: true
 publishedAt: 2023-08-07T15:42:12.174Z
 ---
 ## Introduction

--- a/content/posts/crafting-awesome-wordpress-site.md
+++ b/content/posts/crafting-awesome-wordpress-site.md
@@ -1,14 +1,11 @@
 ---
 title: Crafting the Awesome WordPress Site from Scratch
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: crafting-awesome-wordpress-site
 description: A story about creating a WordPress site from scratch
-tags: wordpress
+tags: [wordpress]
 coverImage: /images/aww-logo-UxMD.png
-featured: yes
+featured: true
 publishedAt: 2023-10-23T07:29:51.202Z
 ---
 ## Table of contents

--- a/content/posts/how-i-kept-coding-under-missile-attacks.md
+++ b/content/posts/how-i-kept-coding-under-missile-attacks.md
@@ -1,13 +1,10 @@
 ---
 publishedAt: '2022-08-22T15:42:12.174Z'
 title: "War In Ukraine: How I Kept Coding Under Missile Attacks"
-featured: yes
-tags: 'war, ukraine'
+featured: true
+tags: [war, ukraine]
 description: 'My story about the first days of the war in Ukraine.'
 status: 'published'
-author:
-  name: 'Alex Pavlov '
-  picture: 'https://avatars.githubusercontent.com/u/6662454?v=4'
 slug: 'how-i-kept-coding-under-missile-attacks'
 coverImage: '/assets/war-logo.webp'
 ---

--- a/content/posts/ngrx-store-in-angular.md
+++ b/content/posts/ngrx-store-in-angular.md
@@ -1,14 +1,11 @@
 ---
 title: NGRX Store In Angular
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: ngrx-store-in-angular
 description: Is it worth using NGRX in an Angular app?
-tags: ngrx, angular
+tags: [ngrx, angular]
 coverImage: /assets/ngrx2.png
-featured: no
+featured: false
 publishedAt: 2022-07-30T15:42:12.174Z
 ---
 ## Table of contents

--- a/content/posts/open-folder-in-vscode-with-a-hotkey-or-context-menu-in-macos.md
+++ b/content/posts/open-folder-in-vscode-with-a-hotkey-or-context-menu-in-macos.md
@@ -1,15 +1,12 @@
 ---
 title: Open Folder In VSCode Using A Context Menu in MacOS
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: open-folder-in-vscode-with-a-hotkey-or-context-menu-in-macos
 description: I’m used to the Open in VSCode context menu action in Windows, but
   it was missing in MacOS. So I found how to add it and want to share it.
-tags: vscode, macos
+tags: [vscode, macos]
 coverImage: /assets/code-in-vs.jpg
-featured: no
+featured: false
 publishedAt: 2020-06-10T15:42:12.174Z
 ---
 # Open a folder in VSCode with a hotkey or context menu in MacOS

--- a/content/posts/tag-based-hierarchy-for-note-taking.md
+++ b/content/posts/tag-based-hierarchy-for-note-taking.md
@@ -1,17 +1,14 @@
 ---
 title: Using Tags Instead Of Folders For In Obsidian
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: tag-based-hierarchy-for-note-taking
 description: Having folder hierarchy for organizing your notes is discouraged in
   Zettelkasten and in some modern note taking applications like Obsidian or Roam
   Research, but having a hierarchy has an advantage in quick search and
   retrieval of notes.
-tags: obsidian, note-taking
+tags: [obsidian, note-taking]
 coverImage: /assets/note-taking.jpg
-featured: no
+featured: false
 publishedAt: 2023-01-22T15:42:12.174Z
 ---
 ## Table of contents

--- a/content/posts/top-10-insights-about-web-app-optimizations.md
+++ b/content/posts/top-10-insights-about-web-app-optimizations.md
@@ -1,16 +1,13 @@
 ---
 title: Top 10 Insights About Web Application Optimization
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: top-10-insights-about-web-app-optimizations
 description: Web application optimization is crucial for any web app. You can
   improve web application performance with Static Site Generation, modern image
   formats, lazy image loading, Next.JS and Preact.
-tags: javascrpt, optimization
+tags: [javascrpt, optimization]
 coverImage: /assets/gear.jpg
-featured: no
+featured: false
 publishedAt: 2022-03-21T15:42:12.174Z
 ---
 ## Table of contents

--- a/content/posts/top-8-tips-on-crypto-investment.md
+++ b/content/posts/top-8-tips-on-crypto-investment.md
@@ -1,15 +1,12 @@
 ---
 title: Top 8 Tips On Crypto Investment
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: top-8-tips-on-crypto-investment
 description: I just want to give you several simple tips that I learned during
   the last several years.
-tags: crypto
+tags: [crypto]
 coverImage: /assets/crypto.webp
-featured: no
+featured: false
 publishedAt: 2020-06-15T15:42:12.174Z
 ---
 ## Table of contents

--- a/content/projects/nextblog.md
+++ b/content/projects/nextblog.md
@@ -1,13 +1,10 @@
 ---
 title: 'NextBlog'
 status: 'published'
-author:
-  name: 'Alex Pavlov '
-  picture: 'https://avatars.githubusercontent.com/u/6662454?v=4'
 slug: 'nextblog'
 description: ''
 coverImage: ''
-technologies: 'NextJS, Contentlayer, NextAuth, Giscus, GitHub API, Codemirror'
+technologies: [NextJS, Contentlayer, NextAuth, Giscus, GitHub API, Codemirror]
 github: 'https://github.com/pavlovtech/WebReaper'
 link: ''
 publishedAt: '2023-09-29T18:38:58.465Z'

--- a/content/projects/pipelined-io.md
+++ b/content/projects/pipelined-io.md
@@ -1,11 +1,8 @@
 ---
 title: pipelined.io
 status: draft
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: pipelined-io
-technologies: NextJS PlanetScale
+technologies: [NextJS PlanetScale]
 link: https://pipelined.io/
 publishedAt: 2023-09-29T18:38:08.174Z
 ---

--- a/content/projects/webreaper.md
+++ b/content/projects/webreaper.md
@@ -1,11 +1,8 @@
 ---
 title: WebReaper
 status: published
-author:
-  name: "Alex Pavlov "
-  picture: https://avatars.githubusercontent.com/u/6662454?v=4
 slug: webreaper
-technologies: .NET, Puppeteer, MongoDB, Redis
+technologies: [.NET, Puppeteer, MongoDB, Redis]
 github: https://github.com/pavlovtech/WebReaper
 link: https://webreaper.ai/
 publishedAt: 2023-09-29T18:37:19.314Z


### PR DESCRIPTION
Follow-up improvements after the Next 16 + Pages CMS migration.

## Frontmatter structure
- **`tags` / `technologies`: comma-string → YAML list.** `tags: 'a, b'` → `tags: [a, b]`. Drops the `.split(",")`/trim plumbing, and Pages CMS now shows proper tag chips (`list: true`). Also makes tag filtering an exact match instead of substring.
- **`featured`: yes/no string → boolean.** The 12 posts mixed quoted `'yes'`/`'no'` and unquoted `yes`/`no` (which only worked by relying on the YAML parser treating them as strings). Now a real `boolean`.
- **`author`: deduplicated.** Removed the identical author block from all 16 files (it also had a trailing-space name) and set one default in `content-collections.ts`.

## Fixes
- **Sitemap:** removed `/pages/*` entries — there's no such route, so they were 404s in the live sitemap.
- **`metadataBase`** set in the root layout → OG/Twitter image URLs resolve to the real domain instead of `localhost:3000`.
- **Tag pages are now statically generated** (`generateStaticParams`) instead of server-rendered on demand.
- **About-me** renders its markdown body as HTML.
- Removed the dead `prose-dark` class; modernized deprecated `legacyBehavior` `<Link>` usages.

## Verified
- `npm run build` ✅ — 37 static pages; all 12 posts + 18 tag pages prerendered (tags went from `ƒ` dynamic to `●` SSG).
- `npm run lint` ✅ clean.
- Runtime: sitemap has no dead page URL; tag/projects/about-me render correctly with the new array/HTML shapes.

## Note
While reviewing, I found **10 of 12 posts are currently `status: draft`** (so hidden from the live blog — only 2 show) — flipped during the Pages CMS editing session. Per your call, I left status untouched. You can flip any back to published in Pages CMS whenever you like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)