### PR TITLE
SEO metadata + security headers

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,9 +7,7 @@ import { IntroLinks } from "app/components/intro-links";
 export const metadata = {
   title: 'Alex Pavlov - blog',
   description: 'Alex Pavlov - blog about programming',
-  languages: {
-    'en-US': '/en-US',
-  },
+  alternates: { canonical: '/blog' },
   keywords: ['Alex Pavlov', 'Blog', '.NET', 'C#', 'JavaScript'],
   creator: 'Alex Pavlov',
   category: 'technology'

--- a/app/blog/posts/[slug]/page.tsx
+++ b/app/blog/posts/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { notFound } from 'next/navigation';
 import { Giscus } from 'app/components/comments/giscus';
 import Image from 'next/image'
 
+const SITE = 'https://alexpavlov.dev'
+
 export const dynamicParams = false
 
 export const generateStaticParams = async () =>
@@ -19,7 +21,13 @@ export async function generateMetadata(
   return {
     title: post.title,
     description: post.description,
+    alternates: { canonical: `/${post.url}` },
     openGraph: {
+      type: 'article',
+      title: post.title,
+      description: post.description,
+      url: `/${post.url}`,
+      publishedTime: post.publishedAt,
       images: post.coverImage ? [post.coverImage] : [],
     },
   }
@@ -32,9 +40,26 @@ const PostPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
   const post = allPosts.find((post) => post.slug === slug);
 
   if (!post) notFound();
-  
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.description,
+    datePublished: post.publishedAt,
+    dateModified: post.publishedAt,
+    author: { '@type': 'Person', name: post.author.name, url: SITE },
+    image: post.coverImage ? `${SITE}${post.coverImage}` : undefined,
+    url: `${SITE}/${post.url}`,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': `${SITE}/${post.url}` },
+  }
+
   return (
     <article className='flex flex-col justify-center'>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mb-8 text-center">
         <time dateTime={post.publishedAt} className="mb-1 text-xs text-gray-600">
           {format(parseISO(post.publishedAt), 'LLLL d, yyyy')}

--- a/app/blog/projects/page.tsx
+++ b/app/blog/projects/page.tsx
@@ -3,11 +3,9 @@ import Card from "app/components/project-card";
 import Link from "next/link";
 
 export const metadata = {
-    title: 'Alex Pavlov - blog',
-    description: 'Alex Pavlov - projects',
-    languages: {
-      'en-US': '/en-US',
-    },
+    title: 'Projects - Alex Pavlov',
+    description: 'A list of projects I have been working on or built',
+    alternates: { canonical: '/blog/projects' },
     keywords: ['Alex Pavlov', 'Projects', '.NET', 'C#', 'JavaScript'],
     creator: 'Alex Pavlov',
 }

--- a/app/blog/tags/[slug]/page.tsx
+++ b/app/blog/tags/[slug]/page.tsx
@@ -10,6 +10,15 @@ export const generateStaticParams = async () =>
     allPosts.filter((post) => post.status === 'published').flatMap((post) => post.tags)
   )].map((slug) => ({ slug }))
 
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug: tag } = await params
+  return {
+    title: `Posts tagged "${tag}" - Alex Pavlov`,
+    description: `Blog posts tagged ${tag}.`,
+    alternates: { canonical: `/blog/tags/${tag}` },
+  }
+}
+
 const TagPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
 
     const { slug: tag } = await params;

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -2,6 +2,12 @@
 import Tag from "app/components/tag";
 import { allPosts } from "content-collections";
 
+export const metadata = {
+  title: 'Tags - Alex Pavlov',
+  description: 'Browse blog posts by topic.',
+  alternates: { canonical: '/blog/tags' },
+}
+
 export default function TagsPage() {
   const allTags = allPosts
     .filter(post => post.status === 'published')

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,32 @@
 import type { NextConfig } from 'next'
 import { withContentCollections } from '@content-collections/next'
 
+// Permissive-but-real CSP: allows the site's known third parties (Giscus
+// comments, Vercel Analytics/Speed Insights, Vercel Live preview toolbar) and
+// https images. 'unsafe-inline' is required for Next's inline bootstrap scripts
+// and next/font styles without a nonce setup.
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://giscus.app https://va.vercel-scripts.com https://vercel.live",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data:",
+  "frame-src https://giscus.app https://vercel.live",
+  "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://giscus.app https://vercel.live",
+  "frame-ancestors 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ')
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: csp },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000' },
+]
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   turbopack: { root: __dirname },
@@ -8,6 +34,9 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       { protocol: 'https', hostname: 'avatars.githubusercontent.com' },
     ],
+  },
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }]
   },
   redirects: async () => [
     { source: '/', destination: '/blog', permanent: true },


### PR DESCRIPTION
The genuinely-worthwhile remainder from the code review (items 1–4).

## SEO
- **Tag pages now have metadata** (they had none): `/blog/tags` gets a title/description/canonical, and `/blog/tags/[slug]` gets a per-tag `generateMetadata` ("Posts tagged X").
- **`BlogPosting` JSON-LD** on post pages (headline, dates, author, image, url) for rich results.
- **Canonical URLs** on every route (`alternates.canonical`), now that `metadataBase` is set.
- **Richer article OpenGraph** on posts (`type: article`, `url`, `publishedTime`).
- Dropped the invalid top-level `languages` metadata key and fixed the Projects page title (was "Alex Pavlov - blog").

## Security headers (`next.config.ts`)
- **CSP** scoped to the site's real third parties — Giscus, Vercel Analytics/Speed Insights, Vercel Live, and `https:` images (`'unsafe-inline'` is required for Next's inline scripts + next/font without a nonce setup).
- **X-Frame-Options**, **X-Content-Type-Options**, **Referrer-Policy**, **Permissions-Policy**, **HSTS** (1y, no `includeSubDomains` so `notes.alexpavlov.dev` is unaffected).

## Verified
`npm run build` ✅ · `npm run lint` ✅ · prod server: all 6 headers present, JSON-LD + canonical render, tag titles correct.

⚠️ **One thing to eyeball after deploy:** the CSP can't be fully exercised headlessly. Please confirm **Giscus comments load** and **analytics report** on a live post — if anything's blocked, the CSP is a one-line relax (or I can switch it to `Content-Security-Policy-Report-Only` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)