### PR TITLE
Fix unreadable post body text (restore prose-dark)

### DIFF
--- a/app/blog/posts/[slug]/page.tsx
+++ b/app/blog/posts/[slug]/page.tsx
@@ -80,7 +80,7 @@ const PostPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
 
       
 
-      <div dangerouslySetInnerHTML={{ __html: post.html }} className='max-w-max prose prose-invert prose-lg mb-5 mt-5'>
+      <div dangerouslySetInnerHTML={{ __html: post.html }} className='max-w-max prose prose-dark prose-invert prose-lg mb-5 mt-5'>
       </div>
       <Giscus />
     </article>


### PR DESCRIPTION
## Problem

Blog post bodies are **hard to read on the live site** — the text renders in the hard-coded `gray-700` (neutral, very dark) on the black theme.

This is a regression from #16: that PR removed `prose-dark` from the post body, thinking it was a no-op. But `tailwind.config.js` defines a custom `prose-dark` typography theme (the light-on-dark text colors); without it, the prose falls back to the dark `DEFAULT.css.color` (`gray-700`).

Affects the 2 published posts currently live.

## Fix

One line in `app/blog/posts/[slug]/page.tsx` — restore `prose-dark`:

```diff
- className='max-w-max prose prose-invert prose-lg mb-5 mt-5'
+ className='max-w-max prose prose-dark prose-invert prose-lg mb-5 mt-5'
```

`prose-dark` applies the dark theme → body text `#d4d4d4` (neutral-300, readable) with pink (`#de1d8d`) links. Verified the resolved color in a build.

The Vercel preview on this PR will show the readable text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)