### PR TITLE
Add Quell to projects

### DIFF
--- a/content/projects/quell.md
+++ b/content/projects/quell.md
@@ -1,0 +1,9 @@
+---
+title: Quell
+status: published
+slug: quell
+technologies: [Web, Mobile, macOS]
+link: https://runquell.com/
+publishedAt: 2026-06-04T10:00:00.000Z
+---
+A deep-focus ritual built on 40 Hz — the gamma rhythm studied for attention. Pairs a binaural beat with a coach in your ear to quiet the noise and do one undivided thing. Web app live; mobile and macOS apps in review.


### PR DESCRIPTION
Adds a projects card for **Quell** ([runquell.com](https://runquell.com/)) — a 40 Hz deep-focus app.

`content/projects/quell.md`:
- The projects page renders each entry's **body** as the card description, so the blurb lives in the body.
- `technologies` lists the **platforms** (web app live; mobile + macOS apps in review) since no implementation stack was specified.
- External-link icon → runquell.com; no GitHub icon (closed source).

Verified: `astro build` clean; the card renders in `dist/blog/projects/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)