### PR TITLE
Add WriteText to projects

### DIFF
--- a/content/projects/writetext.md
+++ b/content/projects/writetext.md
@@ -1,0 +1,9 @@
+---
+title: WriteText
+status: published
+slug: writetext
+technologies: [Swift, SwiftUI, macOS, LLM]
+github: https://github.com/pavlovtech/WriteText
+publishedAt: 2026-06-04T11:00:00.000Z
+---
+A keyboard-first macOS menu bar app that rewrites your text in place with the LLM provider of your choice — OpenAI, Anthropic, Gemini, or local Ollama. Native SwiftUI, bring-your-own-key.


### PR DESCRIPTION
Adds a projects card for **WriteText** ([pavlovtech/WriteText](https://github.com/pavlovtech/WriteText)).

- Blurb (card body) + `technologies` describe the real stack from the repo: native **SwiftUI macOS** menu-bar app, BYOK across OpenAI/Anthropic/Gemini/Ollama.
- GitHub icon only — the repo has no homepage URL, so no external `link`.

Verified: `astro build` clean; card renders in `dist/blog/projects/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)