### PR TITLE
docs: add Built by HighCraft credit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Either:
 - **Directly** — edit the markdown in `content/` and push to the repo.
 
 Posts use frontmatter: `title`, `status` (`published`/`draft`), `slug`, `description`, `tags` (list), `coverImage`, `featured` (boolean), `publishedAt`.
+
+---
+
+Built by [HighCraft.io](https://highcraft.io) — a software and AI engineering team.


### PR DESCRIPTION
Adds a Built-by-HighCraft footer credit so NextBlog's OSS authority flows to highcraft.io (Engine 1 / N0c). README already reflects the Astro stack; this PR is just the credit. Repo topics, description, and template flag were updated separately via the GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)